### PR TITLE
feat(register): add name field, validation and auto-login after successful registration

### DIFF
--- a/lib/src/auth/_children/login/presenter/page/page.dart
+++ b/lib/src/auth/_children/login/presenter/page/page.dart
@@ -46,15 +46,7 @@ class _LoginPageState extends State<LoginPage> {
           listener: (context, state) {
             // Handle state changes
             if (state is LoginLoading) {
-              // Show loading indicator when LoginLoading state is emitted
-              setState(() {
-                _isLoading = true;
-              });
-            } else {
-              // Hide loading indicator for other states
-              setState(() {
-                _isLoading = false;
-              });
+              setState(() => _isLoading = true);
             }
 
             if (state is LoginSuccess) {
@@ -65,34 +57,26 @@ class _LoginPageState extends State<LoginPage> {
               );
             } else if (state is LoginFailure) {
               // Show an error message when login fails
+              setState(() => _isLoading = false);
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(content: Text(state.error)),
               );
             }
           },
           builder: (context, state) {
-            // Build the UI based on the current state
-            return Stack(
-              children: [
-                // LoginForm widget handles the login form UI
-                LoginForm(
-                  emailController: _emailController,
-                  passwordController: _passwordController,
-                  onLogin: (email, password) {
-                    // Dispatch LoginSubmitted event to LoginBloc
-                    context.read<LoginBloc>().add(
-                      LoginSubmitted(username: email, password: password),
-                    );
-                  },
-                ),
-                if (_isLoading)
-                  // Show a loading spinner when _isLoading is true
-                  Container(
-                    color: null,
-                    child: const Center(child: CircularProgressIndicator()),
-                  ),
-              ],
-            );
+            // Conditionally show loading spinner or login form
+            return _isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : LoginForm(
+                    emailController: _emailController,
+                    passwordController: _passwordController,
+                    onLogin: (email, password) {
+                      // Dispatch LoginSubmitted event to LoginBloc
+                      context.read<LoginBloc>().add(
+                        LoginSubmitted(username: email, password: password),
+                      );
+                    },
+                  );
           },
         ),
       ),

--- a/lib/src/auth/_children/register/data/api/register_firebase.repository.dart
+++ b/lib/src/auth/_children/register/data/api/register_firebase.repository.dart
@@ -8,10 +8,10 @@ class RegisterRepositoryFirebase implements RegisterRepository {
       : _firebaseAuth = firebaseAuth ?? firebase.FirebaseAuth.instance;
 
   @override
-  Future<User> register(String username, String password) async {
+  Future<AuthUserInfo> register(String email, String password) async {
     try {
       final userData = await _firebaseAuth.createUserWithEmailAndPassword(
-        email: username,
+        email: email,
         password: password,
       );
 
@@ -20,11 +20,17 @@ class RegisterRepositoryFirebase implements RegisterRepository {
       if (firebaseUser == null) {
         throw AuthException('Unexpected error: user is null after creation.');
       }
+
+      final firebaseIdToken = await firebaseUser.getIdToken();
+
+      if (firebaseIdToken == null) {
+        throw AuthException('Failed authentication');
+      }
       
-      return User(
+      return AuthUserInfo(
         id: firebaseUser.uid,
         email: firebaseUser.email ?? '',
-        username: firebaseUser.displayName ?? username,
+        authProviderToken: firebaseIdToken,
       );
     } on firebase.FirebaseAuthException catch (e) {
       switch (e.code) {

--- a/lib/src/auth/_children/register/data/api/register_firebase.repository.dart
+++ b/lib/src/auth/_children/register/data/api/register_firebase.repository.dart
@@ -8,7 +8,7 @@ class RegisterRepositoryFirebase implements RegisterRepository {
       : _firebaseAuth = firebaseAuth ?? firebase.FirebaseAuth.instance;
 
   @override
-  Future<AuthUserInfo> register(String email, String password) async {
+  Future<AuthUserInfo> register(String name, String email, String password) async {
     try {
       final userData = await _firebaseAuth.createUserWithEmailAndPassword(
         email: email,
@@ -28,6 +28,7 @@ class RegisterRepositoryFirebase implements RegisterRepository {
       }
       
       return AuthUserInfo(
+        name: name,
         id: firebaseUser.uid,
         email: firebaseUser.email ?? '',
         authProviderToken: firebaseIdToken,

--- a/lib/src/auth/_children/register/domain/repository/register.repository.dart
+++ b/lib/src/auth/_children/register/domain/repository/register.repository.dart
@@ -1,5 +1,5 @@
 import 'package:mobile/src/auth/auth.dart';
 
 abstract class RegisterRepository {
-  Future<User> register(String username, String password);
+  Future<AuthUserInfo> register(String email, String password);
 }

--- a/lib/src/auth/_children/register/domain/repository/register.repository.dart
+++ b/lib/src/auth/_children/register/domain/repository/register.repository.dart
@@ -1,5 +1,5 @@
 import 'package:mobile/src/auth/auth.dart';
 
 abstract class RegisterRepository {
-  Future<AuthUserInfo> register(String email, String password);
+  Future<AuthUserInfo> register(String name, String email, String password);
 }

--- a/lib/src/auth/_children/register/presenter/bloc/register_bloc.dart
+++ b/lib/src/auth/_children/register/presenter/bloc/register_bloc.dart
@@ -20,8 +20,8 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     emit(RegisterLoading());
 
     try {
-      final user = await registerRepository.register(event.username, event.password);
-      // emit(RegisterEmailVerificationSent(email: user.email));
+      final user = await registerRepository.register(event.name, event.email, event.password);
+      //TODO BACKEND CALL
       emit(RegisterSuccess(user: user));
     } on AuthException catch (e) {
       final msg = e.message;

--- a/lib/src/auth/_children/register/presenter/bloc/register_bloc.dart
+++ b/lib/src/auth/_children/register/presenter/bloc/register_bloc.dart
@@ -10,7 +10,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
   
   RegisterBloc({required this.registerRepository}) : super(RegisterInitial()) {
     on<RegisterSubmitted>(_onRegisterSubmitted);
-    on<RegisterEmailVerificationChecked>(_onRegisterEmailVerificationChecked);
+    //on<RegisterEmailVerificationChecked>(_onRegisterEmailVerificationChecked);
   }
 
   Future<void> _onRegisterSubmitted(
@@ -22,7 +22,7 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     try {
       final user = await registerRepository.register(event.name, event.email, event.password);
       //TODO BACKEND CALL
-      emit(RegisterSuccess(user: user));
+      emit(RegisterSuccess(user: user, password: event.password));
     } on AuthException catch (e) {
       final msg = e.message;
       if (msg == 'Email already in use') {
@@ -39,10 +39,10 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     }
   }
 
-  Future<void> _onRegisterEmailVerificationChecked(
-    RegisterEmailVerificationChecked event,
-    Emitter<RegisterState> emit,
-  ) async {
-    emit(RegisterSuccess(user: event.user));
-  }
+  // Future<void> _onRegisterEmailVerificationChecked(
+  //   RegisterEmailVerificationChecked event,
+  //   Emitter<RegisterState> emit,
+  // ) async {
+  //   emit(RegisterSuccess(user: event.user));
+  // }
 }

--- a/lib/src/auth/_children/register/presenter/bloc/register_event.dart
+++ b/lib/src/auth/_children/register/presenter/bloc/register_event.dart
@@ -9,12 +9,13 @@ sealed class RegisterEvent extends Equatable {
 
 final class RegisterSubmitted extends RegisterEvent {
 
-  final String username;
+  final String name;
+  final String email;
   final String password;
 
-  const RegisterSubmitted({required this.username, required this.password});
+  const RegisterSubmitted({required this.name, required this.email, required this.password});
 
   @override
-  List<Object> get props => [username, password];
+  List<Object> get props => [name, email, password];
 
 }

--- a/lib/src/auth/_children/register/presenter/bloc/register_state.dart
+++ b/lib/src/auth/_children/register/presenter/bloc/register_state.dart
@@ -31,8 +31,9 @@ class RegisterEmailVerificationChecked extends RegisterEvent {
 
 final class RegisterSuccess extends RegisterState {
   final AuthUserInfo user;
+  final String password;
 
-  const RegisterSuccess({required this.user});
+  const RegisterSuccess({required this.user, required this.password});
 
   @override
   List<Object> get props => [user];

--- a/lib/src/auth/_children/register/presenter/bloc/register_state.dart
+++ b/lib/src/auth/_children/register/presenter/bloc/register_state.dart
@@ -21,7 +21,7 @@ final class RegisterEmailVerificationSent extends RegisterState {
 }
 
 class RegisterEmailVerificationChecked extends RegisterEvent {
-  final User user;
+  final AuthUserInfo user;
 
   const RegisterEmailVerificationChecked({required this.user});
 
@@ -30,7 +30,7 @@ class RegisterEmailVerificationChecked extends RegisterEvent {
 }
 
 final class RegisterSuccess extends RegisterState {
-  final User user;
+  final AuthUserInfo user;
 
   const RegisterSuccess({required this.user});
 

--- a/lib/src/auth/_children/register/presenter/page/page.dart
+++ b/lib/src/auth/_children/register/presenter/page/page.dart
@@ -47,9 +47,9 @@ class RegisterPage extends StatelessWidget {
                   const Center(child: CircularProgressIndicator())
                 else
                   RegisterForm(
-                    onRegister: (email, password) {
+                    onRegister: (name, email, password) {
                       context.read<RegisterBloc>().add(
-                            RegisterSubmitted(username: email, password: password),
+                            RegisterSubmitted(name: name, email: email, password: password),
                           );
                     },
                   ),

--- a/lib/src/auth/_children/register/presenter/page/page.dart
+++ b/lib/src/auth/_children/register/presenter/page/page.dart
@@ -2,8 +2,28 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/src/auth/auth.dart';
 
-class RegisterPage extends StatelessWidget {
+class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,6 +50,10 @@ class RegisterPage extends StatelessWidget {
           listeners: [
             BlocListener<RegisterBloc, RegisterState>(
               listener: (context, state) {
+                if (state is RegisterLoading) {
+                  setState(() => _isLoading = true);
+                }
+
                 if (state is RegisterSuccess) {
                   context.read<LoginBloc>().add(
                     LoginSubmitted(
@@ -38,6 +62,7 @@ class RegisterPage extends StatelessWidget {
                     ),
                   );
                 } else if (state is RegisterFailure) {
+                  setState(() => _isLoading = false);
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(content: Text(state.error)),
                   );
@@ -46,6 +71,9 @@ class RegisterPage extends StatelessWidget {
             ),
             BlocListener<LoginBloc, LoginState>(
               listener: (context, state) {
+                if (state is LoginLoading) {
+                  setState(() => _isLoading = true);
+                }
                 if (state is LoginSuccess) {
                   Navigator.pushAndRemoveUntil(
                     context,
@@ -53,6 +81,7 @@ class RegisterPage extends StatelessWidget {
                     (route) => false,
                   );
                 } else if (state is LoginFailure) {
+                  setState(() => _isLoading = false);
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(content: Text(state.error)),
                   );
@@ -60,25 +89,24 @@ class RegisterPage extends StatelessWidget {
               },
             ),
           ],
-          child: BlocBuilder<RegisterBloc, RegisterState>(
-            builder: (context, state) {
-              return Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (state is RegisterLoading)
-                    const Center(child: CircularProgressIndicator())
-                  else
+          child: _isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
                     RegisterForm(
+                      nameController: _nameController,
+                      emailController: _emailController,
+                      passwordController: _passwordController,
+                      confirmPasswordController: _confirmPasswordController,
                       onRegister: (name, email, password) {
                         context.read<RegisterBloc>().add(
                               RegisterSubmitted(name: name, email: email, password: password),
                             );
                       },
                     ),
-                ],
-              );
-            },
-          ),
+                  ],
+                ),
         ),
       ),
     );

--- a/lib/src/auth/_children/register/presenter/widgets/register_form.dart
+++ b/lib/src/auth/_children/register/presenter/widgets/register_form.dart
@@ -2,19 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:mobile/src/auth/auth.dart';
 
 class RegisterForm extends StatefulWidget {
+  final TextEditingController nameController;
+  final TextEditingController emailController;
+  final TextEditingController passwordController;
+  final TextEditingController confirmPasswordController;
   final Function(String, String, String) onRegister;
 
-  const RegisterForm({super.key, required this.onRegister});
+  const RegisterForm({
+    super.key,
+    required this.nameController,
+    required this.emailController,
+    required this.passwordController,
+    required this.confirmPasswordController,
+    required this.onRegister,
+  });
 
   @override
-  RegisterFormState createState() => RegisterFormState();
+  State<RegisterForm> createState() => RegisterFormState();
 }
 
 class RegisterFormState extends State<RegisterForm> {
-  final _nameController = TextEditingController();
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
-  final _confirmPasswordController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
   bool _isPasswordVisible = false;
 
@@ -46,7 +53,7 @@ class RegisterFormState extends State<RegisterForm> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 25.0),
       child: TextFormField(
-        controller: _nameController,
+        controller: widget.nameController,
         keyboardType: TextInputType.emailAddress,
         decoration: InputDecoration(
           labelText: 'Name',
@@ -68,7 +75,7 @@ class RegisterFormState extends State<RegisterForm> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 25.0),
       child: TextFormField(
-        controller: _emailController,
+        controller: widget.emailController,
         keyboardType: TextInputType.emailAddress,
         decoration: InputDecoration(
           labelText: 'Email',
@@ -90,7 +97,7 @@ class RegisterFormState extends State<RegisterForm> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 25.0),
       child: TextFormField(
-        controller: _passwordController,
+        controller: widget.passwordController,
         obscureText: !_isPasswordVisible,
         decoration: InputDecoration(
           labelText: 'Password',
@@ -122,7 +129,7 @@ class RegisterFormState extends State<RegisterForm> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 25.0),
       child: TextFormField(
-        controller: _confirmPasswordController,
+        controller: widget.confirmPasswordController,
         obscureText: !_isPasswordVisible,
         decoration: InputDecoration(
           labelText: 'Confirm Password',
@@ -136,7 +143,7 @@ class RegisterFormState extends State<RegisterForm> {
           filled: true,
         ),
         validator: (value) {
-          if (value != _passwordController.text) {
+          if (value != widget.passwordController.text) {
             return 'Passwords do not match';
           }
           return null;
@@ -149,7 +156,11 @@ class RegisterFormState extends State<RegisterForm> {
     return PrimaryButton(
       onPressed: () {
         if (_formKey.currentState!.validate()) {
-          widget.onRegister(_nameController.text, _emailController.text, _passwordController.text);
+          widget.onRegister(
+            widget.nameController.text,
+            widget.emailController.text,
+            widget.passwordController.text,
+          );
         }
       },
       isLoading: false,

--- a/lib/src/auth/_children/register/presenter/widgets/register_form.dart
+++ b/lib/src/auth/_children/register/presenter/widgets/register_form.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:mobile/core/globals/widgets/primary_button.dart';
 import 'package:mobile/src/auth/auth.dart';
 
 class RegisterForm extends StatefulWidget {
-  final Function(String, String) onRegister;
+  final Function(String, String, String) onRegister;
 
   const RegisterForm({super.key, required this.onRegister});
 
@@ -12,6 +11,7 @@ class RegisterForm extends StatefulWidget {
 }
 
 class RegisterFormState extends State<RegisterForm> {
+  final _nameController = TextEditingController();
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
@@ -25,6 +25,8 @@ class RegisterFormState extends State<RegisterForm> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
+          _buildNameField(),
+          const SizedBox(height: 20),
           _buildEmailField(),
           const SizedBox(height: 20),
           _buildPasswordField(),
@@ -36,6 +38,28 @@ class RegisterFormState extends State<RegisterForm> {
             child: _buildRegisterButton(),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildNameField() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 25.0),
+      child: TextFormField(
+        controller: _nameController,
+        keyboardType: TextInputType.emailAddress,
+        decoration: InputDecoration(
+          labelText: 'Name',
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: Theme.of(context).colorScheme.primary),
+          ),
+          fillColor: Colors.white,
+          filled: true,
+        ),
+        validator: UserValidator.validateName,
       ),
     );
   }
@@ -125,11 +149,11 @@ class RegisterFormState extends State<RegisterForm> {
     return PrimaryButton(
       onPressed: () {
         if (_formKey.currentState!.validate()) {
-          widget.onRegister(_emailController.text, _passwordController.text);
+          widget.onRegister(_nameController.text, _emailController.text, _passwordController.text);
         }
       },
       isLoading: false,
-      text: 'Register', //  también un String
+      text: 'Register',
     );
   }
 }

--- a/lib/src/auth/domain/models/auth_user_info.dart
+++ b/lib/src/auth/domain/models/auth_user_info.dart
@@ -2,9 +2,12 @@ class AuthUserInfo {
   final String id;
   final String email;
   final String authProviderToken;
+  final String? name;
+
   AuthUserInfo({
     required this.id,
     required this.email,
     required this.authProviderToken,
+    this.name,
   });
 }

--- a/lib/src/auth/validations/schemas/user.schema.dart
+++ b/lib/src/auth/validations/schemas/user.schema.dart
@@ -1,6 +1,23 @@
 import 'package:ez_validator/ez_validator.dart';
 
 class UserValidator {
+
+  static String? validateName(String? value) {
+    final validator = EzValidator<String>()
+        .required('This field is required')
+        .minLength(3, 'The name must be at least 3 characters long')
+        .maxLength(25, 'The name must be at most 25 characters long')
+        .validate(value);
+
+    if (validator != null) return validator;
+
+    if (value != null && !RegExp(r'^[a-zA-Z\s]+$').hasMatch(value)) {
+      return 'The name can only contain letters and spaces';
+    }
+
+    return null;
+  }
+
   static String? validateEmail(String? value) {
     final validator = EzValidator<String>()
         .required('This field is required')


### PR DESCRIPTION
##  Tipo de cambio  
- [x] feat - Nueva funcionalidad  
- [x] refactor - Reestructuración del código

---

##  Descripción breve  
Se mejora el flujo de registro de usuario agregando soporte para nombre, login automático tras registro, y una mejor gestión visual del estado de carga.

---

##  Cambios realizados  
- Se agregó el campo `name` en el formulario de registro y se actualizó su propagación hasta Firebase.  
- Se implementó `MultiBlocListener` en `RegisterPage` para escuchar también el `LoginBloc` y navegar al `HomePage` tras login automático.  
- Se disparó `LoginSubmitted` automáticamente al finalizar el `RegisterSubmitted` exitosamente.  
- Se convirtió `RegisterPage` en `StatefulWidget` para manejar `_isLoading`.  
- Se mejoró la visualización del loading, ocultando el formulario cuando se está cargando.  
- Se preservan los datos del formulario en caso de error de registro.  
- Se simplificó la gestión de estado visual en `LoginPage`.

---

##  Relacionado con  
- Task: 86a7kw09k

---

##  Cómo probarlo  
1. Desde la página de Login debe darle click a Register 
2. Llenar los campos `name`, `email` y `password`.  
3. Hacer clic en "Register".  
4. Verificar que:
   - Se muestra un loader mientras se procesa.  
   - Se redirige automáticamente al `HomePage` si todo sale bien.  
   - En caso de error (correo ya en uso, etc.), los datos ingresados se mantienen.  
5. También podés intentar registrarte con errores (email inválido, password débil) y validar los mensajes.
