### PR TITLE
Feature/test coverage workflow

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,39 @@
+name: Flutter Tests & Coverage
+
+# Allow runners to get read only access to this repository files(set explicitly now because github requires it)
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: 
+      - main
+      - develop
+
+jobs:
+  test-and-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: |
+          docker build -t flutter-tests .
+
+      - name: Run Docker container with tests
+        run: |
+          docker run --rm -v "$GITHUB_WORKSPACE":/app flutter-tests
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,8 +5,12 @@ permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - main
+      - develop
   pull_request:
-    branches: 
+    branches:
       - main
       - develop
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Start from a base image with Flutter which has the version used in this repository
+FROM instrumentisto/flutter:latest
+
+WORKDIR /app
+
+# We only need to copy the entrypoint script to the image to run the tests, we dont need to copy the code since we will use bind mounts to make this container have the entire project
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Activate coverage package globally
+RUN flutter pub global activate coverage
+
+# Run tests and generate coverage
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mobile
 
+[![codecov](https://codecov.io/github/Practica-Supervisada-UCR-2025/mobile/graph/badge.svg?token=9DLEDB9J5G)](https://codecov.io/github/Practica-Supervisada-UCR-2025/mobile)
+
 A new Flutter project.
 
 ## Getting Started

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+flutter pub get
+flutter test --coverage


### PR DESCRIPTION
## Tipo de cambio
[x] ci - Anhadido workflow para generar code coverage y subirlo a Codecov

## Descripción breve
Se crea workflow para que cada vez que se realice un PR o commit directo hacia `main` o `develop` entonces se ejecute el workflow
Tambien se crea un Dockerfile para que se hagan los tests sin tener que descargar flutter ni nada de eso

## Cambios realizados
Solo el README para anhadir el 'badge' de Codecov para este repositorio, todos los demas archivos son nuevos

## Cómo probarlo
El workflow ya se ha ejecutado, se puede ver el reporte de Codecov [aqui](https://app.codecov.io/gh/Practica-Supervisada-UCR-2025/mobile/tree/feature%2Ftest-coverage-workflow)
Se puede probar el Dockerfile, solo hay que ejecutar esto para hacer la imagen
```bash
docker build -t flutter-tests .
```

Y luego correr la imagen en un contenedor
```bash
docker run -v /path/absoluto/apuntando/raiz/de/repo:/app flutter-tests
```
Es **importante** que se haga un bind mount con el argumento `-v` para que el contenedor tenga acceso al codigo, porque necesita tambien escribir en el directorio actual porque el code coverage generado por flutter es un archivo

## Notas adicionales
Para ver el reporte en Codecov, basta con clickear el 'badge' de Codecov en el Readme del repo, o en la pestanha `Checks` en este PR, clickeando el Check que proviene de Codecov(codecov/patch), o tambien a veces en el mismo comentario del bot de Codecov en estos PRs
Pero en este PR especifico no se mostrara al momento el reporte porque se necesita que este PR esta mergeado a `main` para que Codecov pueda mostrar los reportes correctamente