### PR TITLE
fix(forgot_password): adjust timer in forgot password response dialog

### DIFF
--- a/lib/src/auth/_children/forgot-password/presenter/widgets/forgot_password_form.dart
+++ b/lib/src/auth/_children/forgot-password/presenter/widgets/forgot_password_form.dart
@@ -37,37 +37,29 @@ class _ForgotPasswordFormState extends State<ForgotPasswordForm> {
   }
 
   void _showDialog(String title, String message, {bool success = false}) {
-    showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) {
-        Future.delayed(const Duration(seconds: 3), () {
-          if (Navigator.of(dialogContext).canPop()) {
-            Navigator.of(dialogContext).pop();
-            if (success) {
-              Navigator.of(context).pop();
-            }
-          }
-        });
+  showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            child: const Text('Accept'),
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              if (success) {
+                Navigator.of(context).pop();
+              }
+            },
+          ),
+        ],
+      );
+    },
+  );
+}
 
-        return AlertDialog(
-          title: Text(title),
-          content: Text(message),
-          actions: [
-            TextButton(
-              child: const Text('Accept'),
-              onPressed: () {
-                Navigator.of(dialogContext).pop();
-                if (success) {
-                  Navigator.of(context).pop();
-                }
-              },
-            ),
-          ],
-        );
-      },
-    );
-  }
 
   void _onSubmit() {
     final isValid = _formKey.currentState!.validate();

--- a/test/src/auth/_children/forgot-password/presenter/widgets/forgot_password_form_test.dart
+++ b/test/src/auth/_children/forgot-password/presenter/widgets/forgot_password_form_test.dart
@@ -37,12 +37,9 @@ void main() {
   }
 
   Future<void> _submitAndHandleDialog(WidgetTester tester) async {
-    await tester.tap(find.byType(PrimaryButton));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 500));
-    await tester.pump(const Duration(seconds: 3));
-    await tester.pumpAndSettle();
-  }
+  await tester.tap(find.byType(PrimaryButton));
+  await tester.pump();
+}
 
   group('ForgotPasswordForm UI Tests', () {
     testWidgets('Validación: campo vacío muestra error', (tester) async {
@@ -106,17 +103,13 @@ void main() {
           ForgotPasswordSuccess('Correo enviado exitosamente'),
         ]),
         initialState: ForgotPasswordInitial(),
-      );
+    );
 
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.text('Mail sent'), findsOneWidget);
       expect(find.text('Correo enviado exitosamente'), findsOneWidget);
-
-      await tester.pump(const Duration(seconds: 3));
-      await tester.pumpAndSettle();
     });
 
     testWidgets('Muestra dialog de error si ForgotPasswordFailure', (tester) async {
@@ -131,13 +124,9 @@ void main() {
 
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.text('Error'), findsOneWidget);
       expect(find.text('Hubo un error'), findsOneWidget);
-
-      await tester.pump(const Duration(seconds: 3));
-      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
### **Type of change** 
[x] fix - Bug fixes

### **Brief description** 
Adjust the behavior of the forgotten password response dialog according to the PO's feedback.

### **Changes made**  
- Corrected the logic of the success and error dialogs of the forgot password form.
- Ensured correct display and closing of dialogs only when user presses “OK” button.

### **Related to** 
- Task: CU-86a7kw0cb_forgot-password

### **How to test it**  
1. Run the application and select “Forgot Password”.
2. Enter data (can be incorrect or correct), which will generate the dialog displays.
3. The dialogs are closed only when the “OK” button is pressed.

### **Additional notes**  
- No migrations or new variables have been introduced.
