### PR TITLE
feat(create_post): add core UI to create a post

### DIFF
--- a/lib/core/globals/main_scaffold.dart
+++ b/lib/core/globals/main_scaffold.dart
@@ -21,7 +21,7 @@ class MainScaffold extends StatelessWidget {
         context.go(Paths.search);
         break;
       case 2:
-        context.go(Paths.create);
+        context.push(Paths.create);
         break;
       case 3:
         context.go(Paths.notifications);

--- a/lib/core/router/app_routes.dart
+++ b/lib/core/router/app_routes.dart
@@ -32,7 +32,7 @@ final List<RouteBase> appRoutes = [
   ),
   GoRoute(
     path: Paths.create,
-    builder: (context, state) => const CreateScreen(),
+    builder: (context, state) => const CreatePage(),
   ),
   ShellRoute(
     builder: (context, state, child) {

--- a/lib/core/router/app_routes.dart
+++ b/lib/core/router/app_routes.dart
@@ -30,6 +30,10 @@ final List<RouteBase> appRoutes = [
     path: Paths.settings,
     builder: (context, state) => const SettingsScreen(),
   ),
+  GoRoute(
+    path: Paths.create,
+    builder: (context, state) => const CreateScreen(),
+  ),
   ShellRoute(
     builder: (context, state, child) {
       final index = getIndexFromLocation(state.uri.toString());
@@ -43,10 +47,6 @@ final List<RouteBase> appRoutes = [
       GoRoute(
         path: Paths.search,
         builder: (context, state) => const SearchScreen(),
-      ),
-      GoRoute(
-        path: Paths.create,
-        builder: (context, state) => const CreateScreen(),
       ),
       GoRoute(
         path: Paths.notifications,

--- a/lib/src/create/presenter/page/page.dart
+++ b/lib/src/create/presenter/page/page.dart
@@ -1,22 +1,135 @@
 import 'package:flutter/material.dart';
 import 'package:mobile/core/theme/app_colors.dart';
 
-class CreateScreen extends StatelessWidget {
+class CreateScreen extends StatefulWidget {
   const CreateScreen({super.key});
+
+  @override
+  State<CreateScreen> createState() => _CreateScreenState();
+}
+
+class _CreateScreenState extends State<CreateScreen> {
+  final _textController = TextEditingController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
-      body: const Center(
-        child: Text(
-          'Create screen',
-          style: TextStyle(
-            fontSize: 20,
-            color: AppColors.textPrimary,
-            fontWeight: FontWeight.w500,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        elevation: 0,
+        title: const _TopActions(),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _PostTextField(textController: _textController),
+          ),
+          const _BottomBar(),
+        ],
+      ),
+    );
+  }
+}
+
+class _TopActions extends StatelessWidget {
+  const _TopActions();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 14,
+            ),
           ),
         ),
+        const Spacer(),
+        TextButton(
+          onPressed: () {
+            // Action to post the content
+          },
+          style: TextButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+          child: const Text(
+            'Post',
+            style: TextStyle(
+              fontWeight: FontWeight.w800,
+              fontSize: 13,
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class _PostTextField extends StatelessWidget {
+  final TextEditingController textController;
+
+  const _PostTextField({required this.textController});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: TextField(
+        controller: textController,
+        maxLines: null,
+        maxLength: 300,
+        autofocus: true,
+        decoration: const InputDecoration(
+          hintText: 'What’s on your mind?',
+          border: InputBorder.none,
+          counterText: '',
+        ),
+        style: Theme.of(context).textTheme.bodyLarge,
+      ),
+    );
+  }
+}
+
+class _BottomBar extends StatelessWidget {
+  const _BottomBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: Theme.of(context).dividerColor,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.image_outlined),
+            onPressed: () {
+              // Aquí luego iría el image_picker
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/create/presenter/page/page.dart
+++ b/lib/src/create/presenter/page/page.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:mobile/core/theme/app_colors.dart';
+import 'package:mobile/src/create/create.dart';
 
-class CreateScreen extends StatefulWidget {
-  const CreateScreen({super.key});
+class CreatePage extends StatefulWidget {
+  const CreatePage({super.key});
 
   @override
-  State<CreateScreen> createState() => _CreateScreenState();
+  State<CreatePage> createState() => _CreatePageState();
 }
 
-class _CreateScreenState extends State<CreateScreen> {
+class _CreatePageState extends State<CreatePage> {
   final _textController = TextEditingController();
 
   @override
@@ -25,110 +25,14 @@ class _CreateScreenState extends State<CreateScreen> {
         automaticallyImplyLeading: false,
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
-        title: const _TopActions(),
+        title: const TopActions(),
       ),
       body: Column(
         children: [
           Expanded(
-            child: _PostTextField(textController: _textController),
+            child: PostTextField(textController: _textController),
           ),
-          const _BottomBar(),
-        ],
-      ),
-    );
-  }
-}
-
-class _TopActions extends StatelessWidget {
-  const _TopActions();
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(
-            'Cancel',
-            style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface,
-              fontSize: 14,
-            ),
-          ),
-        ),
-        const Spacer(),
-        TextButton(
-          onPressed: () {
-            // Action to post the content
-          },
-          style: TextButton.styleFrom(
-            backgroundColor: AppColors.primary,
-            foregroundColor: Colors.white,
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20),
-            ),
-          ),
-          child: const Text(
-            'Post',
-            style: TextStyle(
-              fontWeight: FontWeight.w800,
-              fontSize: 13,
-            ),
-          ),
-        )
-      ],
-    );
-  }
-}
-
-class _PostTextField extends StatelessWidget {
-  final TextEditingController textController;
-
-  const _PostTextField({required this.textController});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: TextField(
-        controller: textController,
-        maxLines: null,
-        maxLength: 300,
-        autofocus: true,
-        decoration: const InputDecoration(
-          hintText: 'What’s on your mind?',
-          border: InputBorder.none,
-          counterText: '',
-        ),
-        style: Theme.of(context).textTheme.bodyLarge,
-      ),
-    );
-  }
-}
-
-class _BottomBar extends StatelessWidget {
-  const _BottomBar();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        border: Border(
-          top: BorderSide(
-            color: Theme.of(context).dividerColor,
-          ),
-        ),
-      ),
-      child: Row(
-        children: [
-          IconButton(
-            icon: const Icon(Icons.image_outlined),
-            onPressed: () {
-              // Aquí luego iría el image_picker
-            },
-          ),
+          const BottomBar(),
         ],
       ),
     );

--- a/lib/src/create/presenter/presenter.dart
+++ b/lib/src/create/presenter/presenter.dart
@@ -1,1 +1,2 @@
 export 'page/page.dart';
+export 'widgets/widgets.dart';

--- a/lib/src/create/presenter/widgets/bottom_bar.dart
+++ b/lib/src/create/presenter/widgets/bottom_bar.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class BottomBar extends StatelessWidget {
+  const BottomBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: Theme.of(context).dividerColor,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.image_outlined),
+            onPressed: () {
+              // Action to add an image
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/create/presenter/widgets/post_text_field.dart
+++ b/lib/src/create/presenter/widgets/post_text_field.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class PostTextField extends StatelessWidget {
+  final TextEditingController textController;
+
+  const PostTextField({super.key, required this.textController});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: TextField(
+        controller: textController,
+        maxLines: null,
+        maxLength: 300,
+        autofocus: true,
+        decoration: const InputDecoration(
+          hintText: 'What’s on your mind?',
+          border: InputBorder.none,
+          counterText: '',
+        ),
+        style: Theme.of(context).textTheme.bodyLarge,
+      ),
+    );
+  }
+}

--- a/lib/src/create/presenter/widgets/top_actions.dart
+++ b/lib/src/create/presenter/widgets/top_actions.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/core/theme/app_colors.dart';
+
+class TopActions extends StatelessWidget {
+  const TopActions({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            'Cancel',
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 14,
+            ),
+          ),
+        ),
+        const Spacer(),
+        TextButton(
+          onPressed: () {
+            // Action to post the content
+          },
+          style: TextButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+          child: const Text(
+            'Post',
+            style: TextStyle(
+              fontWeight: FontWeight.w800,
+              fontSize: 13,
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/src/create/presenter/widgets/top_actions.dart
+++ b/lib/src/create/presenter/widgets/top_actions.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mobile/core/theme/app_colors.dart';
 
 class TopActions extends StatelessWidget {
@@ -9,7 +10,7 @@ class TopActions extends StatelessWidget {
     return Row(
       children: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () => context.pop(),
           child: Text(
             'Cancel',
             style: TextStyle(

--- a/lib/src/create/presenter/widgets/top_actions.dart
+++ b/lib/src/create/presenter/widgets/top_actions.dart
@@ -10,7 +10,16 @@ class TopActions extends StatelessWidget {
     return Row(
       children: [
         TextButton(
-          onPressed: () => context.pop(),
+          onPressed: () {
+            FocusScope.of(context).unfocus();
+
+            Future.delayed(Duration(milliseconds: 150), () {
+              if (context.mounted) {
+                context.pop();
+              }
+            });
+            
+          },
           child: Text(
             'Cancel',
             style: TextStyle(

--- a/lib/src/create/presenter/widgets/widgets.dart
+++ b/lib/src/create/presenter/widgets/widgets.dart
@@ -1,0 +1,3 @@
+export 'bottom_bar.dart';
+export 'post_text_field.dart';
+export 'top_actions.dart';

--- a/test/core/globals/main_scaffold_test.dart
+++ b/test/core/globals/main_scaffold_test.dart
@@ -55,7 +55,7 @@ void main() {
     await pumpMainScaffold(tester, 1);
     await tester.tap(find.byIcon(Icons.add_box_outlined));
     await tester.pumpAndSettle();
-    verify(() => mockRouter.go('/create')).called(1);
+    verify(() => mockRouter.push('/create')).called(1);
 
     await pumpMainScaffold(tester, 2);
     await tester.tap(find.byIcon(Icons.notifications_none));

--- a/test/core/router/app_routes_test.dart
+++ b/test/core/router/app_routes_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile/core/router/app_routes.dart';
 import 'package:mobile/core/router/paths.dart';
-import 'package:mobile/src/auth/auth.dart';
 
 void main() {
   
@@ -40,7 +39,6 @@ void main() {
     );
     final paths = [
       Paths.search,
-      Paths.create,
       Paths.notifications,
       Paths.profile,
     ];

--- a/test/src/create/presenter/page/page_test.dart
+++ b/test/src/create/presenter/page/page_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mobile/src/create/create.dart';
 
 void main() {
@@ -46,17 +47,35 @@ void main() {
     });
 
     testWidgets('Cancel button exists and can be tapped', (tester) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const Scaffold(body: Text('Home')),
+            routes: [
+              GoRoute(
+                path: 'create',
+                builder: (context, state) => const CreatePage(),
+              ),
+            ],
+          ),
+        ],
+      );
+
       await tester.pumpWidget(
-        const MaterialApp(
-          home: CreatePage(),
+        MaterialApp.router(
+          routerConfig: router,
         ),
       );
+
+      router.push('/create');
+      await tester.pumpAndSettle();
 
       final cancelButton = find.text('Cancel');
       expect(cancelButton, findsOneWidget);
 
       await tester.tap(cancelButton);
-      await tester.pumpAndSettle(); // No hay navegación ahora, pero se puede extender
+      await tester.pumpAndSettle();
     });
 
     testWidgets('Post button exists', (tester) async {

--- a/test/src/create/presenter/page/page_test.dart
+++ b/test/src/create/presenter/page/page_test.dart
@@ -1,15 +1,83 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mobile/core/theme/app_colors.dart';
-import 'package:mobile/src/create/presenter/page/page.dart'; 
+import 'package:mobile/src/create/create.dart';
 
 void main() {
-  testWidgets('CreateScreen displays "Create screen" text', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: CreateScreen(),
-      ),
-    );
-    expect(find.text('Create screen'), findsOneWidget);
+  group('CreatePage', () {
+    testWidgets('renders CreatePage and subcomponents', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      expect(find.byType(CreatePage), findsOneWidget);
+      expect(find.byType(TopActions), findsOneWidget);
+      expect(find.byType(PostTextField), findsOneWidget);
+      expect(find.byType(BottomBar), findsOneWidget);
+    });
+
+    testWidgets('renders a TextField with placeholder', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      // Verifica el placeholder del TextField
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('What’s on your mind?'), findsOneWidget);
+    });
+
+    testWidgets('can enter text in PostTextField', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      final field = find.byType(TextField);
+      expect(field, findsOneWidget);
+
+      await tester.enterText(field, 'Hello world!');
+      await tester.pump();
+
+      expect(find.text('Hello world!'), findsOneWidget);
+    });
+
+    testWidgets('Cancel button exists and can be tapped', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      final cancelButton = find.text('Cancel');
+      expect(cancelButton, findsOneWidget);
+
+      await tester.tap(cancelButton);
+      await tester.pumpAndSettle(); // No hay navegación ahora, pero se puede extender
+    });
+
+    testWidgets('Post button exists', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      final postButton = find.text('Post');
+      expect(postButton, findsOneWidget);
+    });
+
+    testWidgets('BottomBar contains image button icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CreatePage(),
+        ),
+      );
+
+      expect(find.byIcon(Icons.image_outlined), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
This PR introduces only the core UI for the "Create Post" functionality:

- Added a Cancel and Post button.

- Implemented a text field with the placeholder "What's on your mind?"

- Included a bottom bar featuring an image icon for uploading images.

Additionally, I modified the behavior when entering the "Create Post" screen:
The App Bar and Navigation Bar now disappear to allow users to focus entirely on composing their post. I already made the changes on the router tests, so all tests regarding the navigation functionality are still working.

@JGeanca @FerAC – let me know what you think of this UX approach.

Next step:
I'm planning to add a character counter on the right side of the bottom bar in a future PR, as part of the validation enhancements. My next PR should be about the validation

## Note on Dark Mode Background

The background color of the "Create Post" screen is currently not consistent with the rest of the app in dark mode. This is because I didn't use Theme.of(context).colorScheme.background, as it's now deprecated. I tried using color: Theme.of(context).colorScheme.surface, which is the recommended replacement, but it renders a noticeably different tone and I couldn't figure out why.

I even modified the dark theme color values to test, but it didn’t have any effect. I plan to revisit this in a future PR focused specifically on refining the UI. For now, this PR is meant to set up the base UI to start building the core functionality — this is not the final design.

This is the current UI for light mode:

![image](https://github.com/user-attachments/assets/3d1f854b-f6f7-45e6-8d5a-d00882da49eb)

This is the current UI for dark mode:

![image](https://github.com/user-attachments/assets/432be545-840b-4a76-9c80-ca84f1be38d3)
