### PR TITLE
Feature/profile page

### DIFF
--- a/lib/src/profile/presenter/page/page.dart
+++ b/lib/src/profile/presenter/page/page.dart
@@ -137,7 +137,7 @@ class _ProfileScreenState extends State<ProfileScreen>
   Widget _buildCreatePostButton() {
     return SecondaryButton(
       onPressed: () {
-        // todo: Implement create post functionality
+        context.push(Paths.create);
       },
       isLoading: false,
       text: 'New Post',


### PR DESCRIPTION
## Type of change
- `feat` - New functionality  

---

## Brief description

This PR introduces the ability to navigate to create posts from profile page

---

##  Changes made

- Added navigation within profile page

---


##  How to test it

###  On emulator/device:
1. Navigate to profile page
2. Select create post button
3. Confirm that it navigates to create post

##Test Coverage
![captura test](https://github.com/user-attachments/assets/fc63edae-84e0-49ed-aca1-1d517b8553d9)
